### PR TITLE
Makefile: CFLAGS: Add -fno-stack-protector and -U _FORTIFY_SOURCE.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ ARCHS32 := i386
 ARCHS64 := amd64
 ARCHS := $(ARCHS32) $(ARCHS64)
 
-CFLAGS += -pipe -Wall -Wextra -fPIC -fno-ident
+CFLAGS += -pipe -Wall -Wextra -fPIC -fno-ident -fno-stack-protector -U _FORTIFY_SOURCE
 LDFLAGS += -nostartfiles -nodefaultlibs -nostdlib 
 LDFLAGS += -pie -e z_start -Wl,-Bsymbolic,--no-undefined,--build-id=none
 TARGET := loader


### PR DESCRIPTION
Modern compilers on modern distros are usually configured with stack and
buffer overflow protections enabled by default. This leads to name mangling
of some functions and insertion calls to various check functions. E.g.,
build the project on Ubuntu 18.04 with GCC 7.4 leads to:

loader.o: In function `z_entry':
loader.c:(.text+0x61b): undefined reference to `__stack_chk_fail'
z_printf.o: In function `kprintn':
z_printf.c:(.text+0xf8): undefined reference to `__stack_chk_fail'

(And it was the same at least with Ubuntu 16.04).

To disable this behind the scenes modifications of system-level software,
like an ELF loader, add those compiler options.