### PR TITLE
z_printf: Mark a case as FALLTHRU too keep gcc warnings happy.

### DIFF
--- a/src/z_printf.c
+++ b/src/z_printf.c
@@ -128,6 +128,7 @@ reswitch:
 			putcharfd('0', fd);
 			putcharfd('x', fd);
 			lflag += sizeof(void *)==sizeof(unsigned long)? 1 : 0;
+			/* FALLTHRU */
 		case 'x':
 			ul = lflag ? va_arg(ap, unsigned long) : va_arg(ap, unsigned int);
 			kprintn(fd, ul, 16);


### PR DESCRIPTION
Without this, due to -Wall used in the Makefile, following warning is
issued (GCC 4.7):

z_printf.c:130:10: warning: this statement may fall through [-Wimplicit-fallthrough=]
    lflag += sizeof(void *)==sizeof(unsigned long)? 1 : 0;
    ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~